### PR TITLE
[#181294869] fix nokogiri for apple-m1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.7.5-alpine
-RUN apk add --no-cache --update build-base nmap-ncat bash postgresql-dev tzdata shared-mime-info libxml2-dev libxslt-dev
+RUN apk add --no-cache --update build-base nmap-ncat bash postgresql-dev tzdata shared-mime-info libxml2-dev libxslt-dev gcompat
 RUN mkdir -p /src
 WORKDIR /src
 
@@ -16,15 +16,6 @@ RUN wget -q https://archive.promoteapp.net/zeromq-4.0.4.tar.gz -O /src/zeromq-4.
   && cd /src/zeromq-4.0.4 && ./configure && make -j 8 install \
   && rm -rf /src/libsodium-1.0.0* /src/zeromq-4.0.4*
 
-RUN apk add --no-cache --update cargo git \
-  && wget -q https://github.com/mozilla/geckodriver/archive/refs/tags/v0.27.0.tar.gz -O /src/geckodriver-0.27.0.tar.gz \
-  && tar -xvf /src/geckodriver-0.27.0.tar.gz \
-  && ls /src \
-  && cd /src/geckodriver-0.27.0 \
-  && cargo install --path . --bin geckodriver --root /usr \
-  && rm -rf /src/geckodriver* /root/.cargo \
-  && apk del cargo
-
 ## alt 3, prebuilt debian, this doesn't work due to alpine musl issue
 #RUN wget -q https://archive.promoteapp.net/libsodium-1.0.0-deb7-amd64.tar.gz -O /src/libsodium.tar.gz \
 #  && tar -C /usr/local --strip-components=1 -xzf /src/libsodium.tar.gz \
@@ -33,6 +24,23 @@ RUN apk add --no-cache --update cargo git \
 #  && tar -C /usr/local --strip-components=1 -xzf /src/zeromq.tar.gz \
 #  && ldconfig /usr/local \
 #  && rm /src/zeromq.tar.gz /src/libsodium.tar.gz
+
+# geckodriver is only available prebuilt in alpine edge testing, might be included in alpine v3.16 ~2022-06
+# option 1: fast + weird, 35sec, upgrade to alpine edge and use prebuilt 0.30.0
+#RUN sed -i -e 's/v3\.../edge/g' /etc/apk/repositories \
+#  && echo "https://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
+#  && apk update \
+#  && apk upgrade --available \
+#  && apk add geckodriver
+# option 2: compile ourself
+RUN apk add --no-cache --update cargo git \
+  && wget -q https://github.com/mozilla/geckodriver/archive/refs/tags/v0.27.0.tar.gz -O /src/geckodriver-0.27.0.tar.gz \
+  && tar -xvf /src/geckodriver-0.27.0.tar.gz \
+  && ls /src \
+  && cd /src/geckodriver-0.27.0 \
+  && cargo install --path . --bin geckodriver --root /usr \
+  && rm -rf /src/geckodriver* /root/.cargo \
+  && apk del cargo
 
 # Used for waiting on runtime dependencies
 # For example db:migrate requires postgres server


### PR DESCRIPTION
nokogiri requires the gcompat package. Also rearranged the docs a bit
